### PR TITLE
Add OpenNIC alternative DNS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ The [Drogulus](http://drogul.us/) (WIP) is a programmable peer-to-peer data stor
 
 [Nightweb](https://nightweb.net/) connects your Android device or PC to an anonymous, peer-to-peer social network. You can write posts and share photos, and your followers will retrieve them using BitTorrent running over the I2P anonymous network. It is still experimental.
 
+### OpenNIC
+
+[OpenNIC Project](http://www.opennicproject.org/) is an alternative DNS provider that is open and democratic.
+
 ### Osiris
 
 [Osiris](http://www.osiris-sps.org/) is software for decentralized portal, managed and shared via P2P between members.


### PR DESCRIPTION
Added the OpenNIC Project, an alternative DNS provider. Not really an alternative internet like the other projects in the list but a good alternative to your ISP's or Google's DNS providers.
