### PR TITLE
Add Coinpunk (self-hosted bitcoin wallet) to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Pull requests VERY welcome!
 
 [Camlistore](http://camlistore.org/) is your personal storage system for life. It is an acronym for "Content-Addressable Multi-Layer Indexed Storage" and could be described as "Like git for all content in your life"
 
+### Coinpunk
+
+[Coinpunk](http://coinpunk.org/) is a web application that allows anyone to run their own self-hosted Bitcoin wallet service that is accessible from your web browser anywhere in the world. It's free, open source, and you can install it on your server right now.
+
+
 ### Commotion Wireless
 
 [Commotion Wireless](https://commotionwireless.net) is an open-source communication tool that uses mobile phones, computers, and other wireless devices to create decentralized mesh networks.


### PR DESCRIPTION
Coinpunk is an open source, self-hosted DIY bitcoin wallet service you can run on your own server
