### PR TITLE
Add Mail-in-a-Box

### DIFF
--- a/projects/Mail-in-a-Box.json
+++ b/projects/Mail-in-a-Box.json
@@ -1,0 +1,7 @@
+{
+  "name": "Mail-in-a-Box",
+  "description": "[Mail-in-a-Box](https://github.com/JoshData/mailinabox) helps individuals take back control of their email by defining a one-click, easy-to-deploy SMTP+everything else server: a mail server in a box. It provides a single shell script that turns a fresh Ubuntu 14.04 LTS 64-bit machine into a working mail server, including an SMTP server, IMAP server, webmail interface, spam filtering, DKIM signing, DNS server, firewall and intrusion prevention.",
+  "ohloh": {
+    "skip": true
+  }
+}


### PR DESCRIPTION
_[Mail-in-a-Box](https://github.com/JoshData/mailinabox) helps individuals take back control of their email by defining a one-click, easy-to-deploy SMTP+everything else server: a mail server in a box. It provides a single shell script that turns a fresh Ubuntu 14.04 LTS 64-bit machine into a working mail server, including an SMTP server, IMAP server, webmail interface, spam filtering, DKIM signing, DNS server, firewall and intrusion prevention._
