### PR TITLE
Fix git index entry for Buddycloud.json

### DIFF
--- a/projects/Buddycloud.json
+++ b/projects/Buddycloud.json
@@ -1,8 +1,0 @@
-{
-    "name": "Buddycloud",
-    "description": "[Buddycloud](http://buddycloud.com) is built for people who care about their privacy. We are building the future of social networks. A future founded on openness. A future built using open standards. 
-We are making the future happen now, by building a massively scaled and fully distributed social network. Buddycloud is leading a quiet revolution to replace the closed retweet and like incumbents.",
-    "ohloh": {
-      "id": "535958"
-    }
-}


### PR DESCRIPTION
Somehow a recent update (probably made from a Windows machine with a
filesystem that doesn't properly distinguish between files with
different cases) merged in a change that added buddycloud.json but left
this file lying around.  This leads to weird behaviors in fresh git
clones on filesystems that have case-sensitivity.  Removing the
duplicate file; Buddycloud.json appears to have less data so that is the
one I'm removing.
