### PR TITLE
Tiki Suite has become WikiSuite

### DIFF
--- a/projects/Tiki Suite.json
+++ b/projects/Tiki Suite.json
@@ -1,6 +1,6 @@
 {
-    "description": "[Tiki Suite](https://suite.tiki.org/Tiki+Suite) is a selection of Free / Libre / Open Source Software (FLOSS) server, web, mobile and desktop apps with a concerted effort for greater interoperability, security and adaptability, which is aimed at small & medium-sized organizations.  The Tiki Suite is especially suited to decentralized and knowledge-centric organizations and offers most (80%+) of the features all organizations need, such as: Email, Website & Blog, Shopping Cart, Intranet & Project Management, E-learning, Social Networking, Knowledge base, File sharing, Issue Tracker, Video-conferencing, LDAP, VPN, Gateway, Network, etc.  You can install anywhere (home, office, laptop, rented server, etc.)", 
-    "name": "Tiki Suite", 
+    "description": "[WikiSuite](http://WikiSuite.org/) is the most comprehensive and integrated Free / Libre / Open Source software suite ever developed. WikiSuite is especially suited to knowledge-centric organizations and offers most (80%+) of the data and information management features all organizations need, such as OS and Network, Web and Intranet, Email and Calendar, Files and Sync, BPM and Analytics, Chat and Video Conference, and Commerce. Key components include ClearOS, Openfire Meetings, Tiki Wiki CMS Groupware (aka TikiWiki), Kolab, Syncthing, FusionPBX and FreeSWITCH, Piwik, Elasticsearch and Kibana, Kaltura, Xibo and Kimchi (KVM). ", 
+    "name": "WikiSuite", 
     "ohloh": {
         "skip": true
     }


### PR DESCRIPTION
If useful, can you rename Tiki Suite.json -> WikiSuite.json  ?   Thanks!
