### PR TITLE
Add ZeroNet

### DIFF
--- a/projects/zeronet.json
+++ b/projects/zeronet.json
@@ -1,0 +1,4 @@
+{
+  "name": "HelloZeroNet",
+  "description": "Open, free and uncensorable websites, using Bitcoin cryptography and BitTorrent network."
+}


### PR DESCRIPTION
The project name is actually ZeroNet (without the "Hello"), but [under Ohloh it's listed as HelloZeroNet](https://www.openhub.net/p/HelloZeroNet). I can't find the Ohloh id anywhere on the page, which is why I've done this instead of specifying an id. 