### PR TITLE
fix scuttlebutt link

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ A collection of interesting networks and technology aiming at re-decentralizing 
 
 - [Mastodon](https://joinmastodon.org/) is “the world’s largest free, open-source, decentralized microblogging network.”
 
-* [Scuttlebot](https://github.com/ssbc/scuttlebot) gossip based p2p social media feeds.
+* [Scuttlebutt](https://www.scuttlebutt.nz) gossip based p2p community social media, chess, book reviews, gatherings, ... (code [here](https://www.github.com/ssbc))
 
 ## Uncategorised
 


### PR DESCRIPTION
Hi, I'm one of the community gardeners of scuttlebutt, I've changed the link to point at the main landing page which has the best links out to all info people might be interested in