### PR TITLE
Add Nextcloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A collection of interesting networks and technology aiming at re-decentralizing 
 - [ClearSkies](https://github.com/jewel/clearskies) is a peer-to-peer file sync program.  It is inspired by BitTorrent Sync, but has an open and fully-documented protocol.
 - [Perkeep (was Camlistore)](http://perkeep.org/) is your personal storage system for life. It is an acronym for "Content-Addressable Multi-Layer Indexed Storage" and could be described as "Like git for all content in your life"
 - [Swarm](https://swarm.ethereum.org) is a distributed storage platform and content distribution service, a native base layer service of the ethereum web3 stack. It uses the ethereum economy to incentivize P2P storage.
-
+- [Nextcloud](https://nextcloud.com) is a selfhosted, federated alternative to Google Docs/Office365 et all. It syncs and lets you share files but it's over 200 community-contributed apps add chat and audio/video calls, calendar/contact, mail, maps, Tasks, collaborative document editing, Kanban board, password manager, bookmarks, audio player and many more. It is easy to install and manage (as far as servers go...) and extremely secure.
 
 
 ## Collaborative Web Editors


### PR DESCRIPTION
I was a little surprised to see what's probably the most popular private cloud solution not listed (there are >250.000 Nextcloud servers on the web, likely more than all others mentioned here combined). I think Cozy is the closest to Nextcloud in terms of functionality, Seafile does at least the file sync and document editing. I also do miss Pydio in the list... Could add it if you want me to?!?